### PR TITLE
Add numpy pandas to Dockerfile so example runs out of the box

### DIFF
--- a/lambdamap_cdk/stack/Dockerfile
+++ b/lambdamap_cdk/stack/Dockerfile
@@ -13,7 +13,7 @@ RUN yum update -y \
         gcc-c++ make openssl-devel zlib-devel readline-devel git
 
 RUN /bin/bash -c "${EXTRA_CMDS}"
-RUN pip install awslambdaric cloudpickle==1.6.0
+RUN pip install awslambdaric cloudpickle==1.6.0 numpy pandas
 RUN touch ${LAMBDA_TASK_ROOT}/logs.log && chmod a+rwx ${LAMBDA_TASK_ROOT}/logs.log
 
 COPY lambda.py ${LAMBDA_TASK_ROOT}


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Install numpy and pandas in Dockerfile so that the example on the project root can run directly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
